### PR TITLE
ci: migrate remote-dispatch to workflow_call

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -64,6 +64,28 @@ jobs:
       WINDOWS_SHA: ${{ inputs.windows_sha || github.event.client_payload.windows_sha }}
 
     steps:
+    # ── Validate inputs -----------------------------------------------------
+    - name: Validate inputs
+      shell: bash
+      run: |
+        case "$COMPONENT" in
+          gardenlogin|gardenctl-v2|diki) ;;
+          *)
+            echo "Error: Invalid component '$COMPONENT'"
+            exit 1
+            ;;
+        esac
+
+        if ! echo "$FULL_TAG" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+          echo "Error: Invalid tag '$FULL_TAG'"
+          exit 1
+        fi
+
+        if ! echo "$WINDOWS_SHA" | grep -qE '^[0-9a-f]{64}$'; then
+          echo "Error: Invalid SHA256 for WINDOWS_SHA"
+          exit 1
+        fi
+
     # ── Map component ➜ metadata --------------------------------------------
     - id: meta
       name: Resolve paths / flags

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -46,7 +46,7 @@ jobs:
       - id: strip
         shell: pwsh
         run: |
-          $num = "${{ env.TAG }}".Replace('v','')
+          $num = "$env:TAG".Replace('v','')
           echo "num=$num" >> $env:GITHUB_OUTPUT
 
 ##############################################################################
@@ -68,7 +68,7 @@ jobs:
       name: Resolve paths / flags
       shell: bash
       run: |
-        case "${{ env.COMPONENT }}" in
+        case "$COMPONENT" in
           gardenlogin)
             echo "SCRIPT=.github/workflows/update-gardenlogin.ps1" >> $GITHUB_OUTPUT
             echo "NUSPEC=gardenlogin/gardenlogin.nuspec"           >> $GITHUB_OUTPUT
@@ -93,7 +93,7 @@ jobs:
             echo "SKIP_VAR=SKIP_CHOCO_PUSH_DIKI"                    >> $GITHUB_OUTPUT
             echo "EXTRA_PATHS=diki/tools/chocolateyinstall.ps1"     >> $GITHUB_OUTPUT
             ;;
-          *) echo "Invalid component: ${{ env.COMPONENT }}" && exit 1 ;;
+          *) echo "Invalid component: $COMPONENT" && exit 1 ;;
         esac
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
@@ -103,18 +103,23 @@ jobs:
     # ── Update nuspec & helper scripts ---------------------------------------
     - name: Update package source files
       shell: pwsh
+      env:
+        SCRIPT: ${{ steps.meta.outputs.SCRIPT }}
       run: |
-        & "${{ steps.meta.outputs.SCRIPT }}" `
-          "${{ env.FULL_TAG }}" `
-          "${{ env.WINDOWS_SHA }}"
+        & "$env:SCRIPT" `
+          "$env:FULL_TAG" `
+          "$env:WINDOWS_SHA"
 
     # ── Pack -----------------------------------------------------------------
     - name: Choco pack
       shell: pwsh
+      env:
+        NUSPEC: ${{ steps.meta.outputs.NUSPEC }}
+        PKG_DIR: ${{ steps.meta.outputs.PKG_DIR }}
       run: |
-        choco pack ${{ steps.meta.outputs.NUSPEC }} `
-                   --version ${{ env.NUM_VERSION }} `
-                   -y --outdir ${{ steps.meta.outputs.PKG_DIR }}
+        choco pack $env:NUSPEC `
+                   --version $env:NUM_VERSION `
+                   -y --outdir $env:PKG_DIR
 
     # ── Push (repo flag & manual flag respected) -----------------------------
     - name: Choco push
@@ -124,10 +129,12 @@ jobs:
       shell: pwsh
       env:
         CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        PKG_DIR: ${{ steps.meta.outputs.PKG_DIR }}
+        PKG_NAME: ${{ steps.meta.outputs.PKG_NAME }}
       run: |
-        choco push "${{ steps.meta.outputs.PKG_DIR }}\${{ steps.meta.outputs.PKG_NAME }}.${{ env.NUM_VERSION }}.nupkg" `
+        choco push "$env:PKG_DIR\$env:PKG_NAME.$env:NUM_VERSION.nupkg" `
                    --source https://chocolatey.org `
-                   -k $Env:CHOCOLATEY_API_KEY
+                   -k $env:CHOCOLATEY_API_KEY
 
     - name: Push skipped
       if: ${{ vars[steps.meta.outputs.SKIP_VAR] == 'true' ||
@@ -157,6 +164,11 @@ jobs:
       env:
         GIT_PUSH_TOKEN: ${{ github.token }}
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        PKG_DIR: ${{ steps.meta.outputs.PKG_DIR }}
+        PKG_NAME: ${{ steps.meta.outputs.PKG_NAME }}
+        NUSPEC: ${{ steps.meta.outputs.NUSPEC }}
+        EXTRA_PATHS: ${{ steps.meta.outputs.EXTRA_PATHS }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
         BASIC_AUTH="$(printf 'x-access-token:%s' "$GIT_PUSH_TOKEN" | base64 | tr -d '\n')"
         AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
@@ -172,20 +184,20 @@ jobs:
           git "$@"
         }
 
-        branch="update_${{ env.COMPONENT }}_${{ env.FULL_TAG }}"
+        branch="update_${COMPONENT}_${FULL_TAG}"
         git switch -c "$branch"
 
-        git add "${{ steps.meta.outputs.PKG_DIR }}\\${{ steps.meta.outputs.PKG_NAME }}.${{ env.NUM_VERSION }}.nupkg"
-        git add "${{ steps.meta.outputs.NUSPEC }}"
-        for p in ${{ steps.meta.outputs.EXTRA_PATHS }};
+        git add "${PKG_DIR}\\${PKG_NAME}.${NUM_VERSION}.nupkg"
+        git add "$NUSPEC"
+        for p in $EXTRA_PATHS;
           do git add "$p";
         done
 
-        git commit -m "update ${{ env.COMPONENT }} to ${{ env.FULL_TAG }}" || echo "nothing new"
+        git commit -m "update $COMPONENT to $FULL_TAG" || echo "nothing new"
         git_with_auth push --force-with-lease -u origin "$branch"
 
         gh pr create \
           --head "$branch" \
-          --base "${{ github.event.repository.default_branch }}" \
-          --title "update ${{ env.COMPONENT }} to ${{ env.FULL_TAG }}" \
-          --body  "Updates Chocolatey package for **${{ env.COMPONENT }}** (${{ env.FULL_TAG }})."
+          --base "$DEFAULT_BRANCH" \
+          --title "update $COMPONENT to $FULL_TAG" \
+          --body  "Updates Chocolatey package for **$COMPONENT** ($FULL_TAG)."

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -1,8 +1,6 @@
 name: Update Chocolatey Package
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 # ───────────── TRIGGERS ─────────────
 on:
@@ -55,6 +53,9 @@ jobs:
   package-push:
     needs: version-info
     runs-on: windows-latest
+    permissions:
+      contents: write
+      id-token: write
 
     env:
       FULL_TAG:   ${{ inputs.tag || github.event.client_payload.tag }}

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -97,6 +97,8 @@ jobs:
         esac
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      with:
+        persist-credentials: false
 
     # ── Update nuspec & helper scripts ---------------------------------------
     - name: Update package source files
@@ -153,8 +155,23 @@ jobs:
     - name: Create / update pull request
       shell: bash
       env:
+        GIT_PUSH_TOKEN: ${{ github.token }}
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       run: |
+        BASIC_AUTH="$(printf 'x-access-token:%s' "$GIT_PUSH_TOKEN" | base64 | tr -d '\n')"
+        AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
+
+        echo "::add-mask::$GIT_PUSH_TOKEN"
+        echo "::add-mask::$BASIC_AUTH"
+        echo "::add-mask::$AUTH_HEADER"
+
+        git_with_auth() {
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+          GIT_CONFIG_VALUE_0="$AUTH_HEADER" \
+          git "$@"
+        }
+
         branch="update_${{ env.COMPONENT }}_${{ env.FULL_TAG }}"
         git switch -c "$branch"
 
@@ -165,7 +182,7 @@ jobs:
         done
 
         git commit -m "update ${{ env.COMPONENT }} to ${{ env.FULL_TAG }}" || echo "nothing new"
-        git push --force-with-lease -u origin "$branch"
+        git_with_auth push --force-with-lease -u origin "$branch"
 
         gh pr create \
           --head "$branch" \

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -30,197 +30,246 @@ on:
         default: false
 
 ##############################################################################
-# 1) PRE-FLIGHT — strip leading “v”, shared by all components
+# 1) RESOLVE INPUTS — validate & emit metadata (no repo access needed)
 ##############################################################################
 jobs:
-  version-info:
+  resolve-inputs:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
-      numeric: ${{ steps.strip.outputs.num }}
-    env:
-      TAG: ${{ inputs.tag || github.event.client_payload.tag }}
+      full_tag: ${{ steps.validate.outputs.full_tag }}
+      numeric: ${{ steps.validate.outputs.numeric }}
+      component: ${{ steps.validate.outputs.component }}
+      windows_sha: ${{ steps.validate.outputs.windows_sha }}
+      script: ${{ steps.meta.outputs.SCRIPT }}
+      nuspec: ${{ steps.meta.outputs.NUSPEC }}
+      pkg_dir: ${{ steps.meta.outputs.PKG_DIR }}
+      pkg_name: ${{ steps.meta.outputs.PKG_NAME }}
+      skip_var: ${{ steps.meta.outputs.SKIP_VAR }}
+      extra_paths: ${{ steps.meta.outputs.EXTRA_PATHS }}
 
     steps:
-      - id: strip
-        shell: pwsh
+      - name: Validate inputs
+        id: validate
+        shell: bash
+        env:
+          FULL_TAG: ${{ inputs.tag || github.event.client_payload.tag }}
+          COMPONENT: ${{ inputs.component || github.event.client_payload.component }}
+          WINDOWS_SHA: ${{ inputs.windows_sha || github.event.client_payload.windows_sha }}
         run: |
-          $num = "$env:TAG".Replace('v','')
-          echo "num=$num" >> $env:GITHUB_OUTPUT
+          case "$COMPONENT" in
+            gardenlogin|gardenctl-v2|diki) ;;
+            *)
+              echo "Error: Invalid component '$COMPONENT'"
+              exit 1
+              ;;
+          esac
+
+          if ! echo "$FULL_TAG" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "Error: Invalid tag '$FULL_TAG'"
+            exit 1
+          fi
+
+          if ! echo "$WINDOWS_SHA" | grep -qE '^[0-9a-f]{64}$'; then
+            echo "Error: Invalid SHA256 for WINDOWS_SHA"
+            exit 1
+          fi
+
+          NUMERIC="${FULL_TAG#v}"
+          echo "full_tag=$FULL_TAG" >> "$GITHUB_OUTPUT"
+          echo "numeric=$NUMERIC" >> "$GITHUB_OUTPUT"
+          echo "component=$COMPONENT" >> "$GITHUB_OUTPUT"
+          echo "windows_sha=$WINDOWS_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve paths / flags
+        id: meta
+        shell: bash
+        env:
+          COMPONENT: ${{ steps.validate.outputs.component }}
+        run: |
+          case "$COMPONENT" in
+            gardenlogin)
+              echo "SCRIPT=.github/workflows/update-gardenlogin.ps1" >> "$GITHUB_OUTPUT"
+              echo "NUSPEC=gardenlogin/gardenlogin.nuspec"           >> "$GITHUB_OUTPUT"
+              echo "PKG_DIR=gardenlogin"                             >> "$GITHUB_OUTPUT"
+              echo "PKG_NAME=gardenlogin"                            >> "$GITHUB_OUTPUT"
+              echo "SKIP_VAR=SKIP_CHOCO_PUSH_GARDENLOGIN"            >> "$GITHUB_OUTPUT"
+              echo "EXTRA_PATHS=gardenlogin/tools/chocolateyinstall.ps1 gardenlogin/tools/chocolateyuninstall.ps1" >> "$GITHUB_OUTPUT"
+              ;;
+            gardenctl-v2)
+              echo "SCRIPT=.github/workflows/update-gardenctl-v2.ps1" >> "$GITHUB_OUTPUT"
+              echo "NUSPEC=gardenctl-v2/gardenctl-v2.nuspec"          >> "$GITHUB_OUTPUT"
+              echo "PKG_DIR=gardenctl-v2"                             >> "$GITHUB_OUTPUT"
+              echo "PKG_NAME=gardenctl-v2"                            >> "$GITHUB_OUTPUT"
+              echo "SKIP_VAR=SKIP_CHOCO_PUSH_GARDENCTL_V2"            >> "$GITHUB_OUTPUT"
+              echo "EXTRA_PATHS=gardenctl-v2/tools/chocolateyinstall.ps1" >> "$GITHUB_OUTPUT"
+              ;;
+            diki)
+              echo "SCRIPT=.github/workflows/update-diki.ps1"         >> "$GITHUB_OUTPUT"
+              echo "NUSPEC=diki/diki.nuspec"                          >> "$GITHUB_OUTPUT"
+              echo "PKG_DIR=diki"                                     >> "$GITHUB_OUTPUT"
+              echo "PKG_NAME=diki"                                    >> "$GITHUB_OUTPUT"
+              echo "SKIP_VAR=SKIP_CHOCO_PUSH_DIKI"                    >> "$GITHUB_OUTPUT"
+              echo "EXTRA_PATHS=diki/tools/chocolateyinstall.ps1"     >> "$GITHUB_OUTPUT"
+              ;;
+            *) echo "Invalid component: $COMPONENT" && exit 1 ;;
+          esac
 
 ##############################################################################
-# 2) PACKAGE-PUSH — one matrix row (component) resolved at runtime
+# 2) PACKAGE — checkout, update sources, choco pack, upload artifact
 ##############################################################################
-  package-push:
-    needs: version-info
+  package:
+    needs: resolve-inputs
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    env:
+      FULL_TAG: ${{ needs.resolve-inputs.outputs.full_tag }}
+      NUM_VERSION: ${{ needs.resolve-inputs.outputs.numeric }}
+      COMPONENT: ${{ needs.resolve-inputs.outputs.component }}
+      WINDOWS_SHA: ${{ needs.resolve-inputs.outputs.windows_sha }}
+      PKG_DIR: ${{ needs.resolve-inputs.outputs.pkg_dir }}
+      PKG_NAME: ${{ needs.resolve-inputs.outputs.pkg_name }}
+      NUSPEC: ${{ needs.resolve-inputs.outputs.nuspec }}
+      SCRIPT: ${{ needs.resolve-inputs.outputs.script }}
+      EXTRA_PATHS: ${{ needs.resolve-inputs.outputs.extra_paths }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Update package source files
+        shell: pwsh
+        run: |
+          & "$env:SCRIPT" `
+            "$env:FULL_TAG" `
+            "$env:WINDOWS_SHA"
+
+      - name: Choco pack
+        shell: pwsh
+        run: |
+          choco pack $env:NUSPEC `
+                     --version $env:NUM_VERSION `
+                     -y --outdir $env:PKG_DIR
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: package-update
+          path: ${{ env.PKG_DIR }}/
+          if-no-files-found: error
+          retention-days: 1
+
+##############################################################################
+# 3) PUBLISH — download nupkg, push to Chocolatey
+##############################################################################
+  publish-chocolatey:
+    needs: [resolve-inputs, package]
+    runs-on: windows-latest
+    permissions: {}
+    if: ${{ vars[needs.resolve-inputs.outputs.skip_var] != 'true' &&
+            (github.event_name == 'repository_dispatch' ||
+             inputs.push_to_chocolatey) }}
+
+    env:
+      NUM_VERSION: ${{ needs.resolve-inputs.outputs.numeric }}
+      PKG_DIR: ${{ needs.resolve-inputs.outputs.pkg_dir }}
+      PKG_NAME: ${{ needs.resolve-inputs.outputs.pkg_name }}
+
+    steps:
+      - name: Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package-update
+
+      - name: Choco push
+        shell: pwsh
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          choco push "$env:PKG_NAME.$env:NUM_VERSION.nupkg" `
+                     --source https://chocolatey.org `
+                     -k $env:CHOCOLATEY_API_KEY
+
+##############################################################################
+# 4) CREATE PR — commit generated files, push branch, open PR
+##############################################################################
+  create-pr:
+    needs: [resolve-inputs, package]
     runs-on: windows-latest
     permissions:
       contents: write
       id-token: write
 
     env:
-      FULL_TAG:   ${{ inputs.tag || github.event.client_payload.tag }}
-      NUM_VERSION: ${{ needs.version-info.outputs.numeric }}
-      COMPONENT: ${{ inputs.component || github.event.client_payload.component }}
-      WINDOWS_SHA: ${{ inputs.windows_sha || github.event.client_payload.windows_sha }}
+      FULL_TAG: ${{ needs.resolve-inputs.outputs.full_tag }}
+      NUM_VERSION: ${{ needs.resolve-inputs.outputs.numeric }}
+      COMPONENT: ${{ needs.resolve-inputs.outputs.component }}
+      PKG_DIR: ${{ needs.resolve-inputs.outputs.pkg_dir }}
+      PKG_NAME: ${{ needs.resolve-inputs.outputs.pkg_name }}
+      NUSPEC: ${{ needs.resolve-inputs.outputs.nuspec }}
+      EXTRA_PATHS: ${{ needs.resolve-inputs.outputs.extra_paths }}
 
     steps:
-    # ── Validate inputs -----------------------------------------------------
-    - name: Validate inputs
-      shell: bash
-      run: |
-        case "$COMPONENT" in
-          gardenlogin|gardenctl-v2|diki) ;;
-          *)
-            echo "Error: Invalid component '$COMPONENT'"
-            exit 1
-            ;;
-        esac
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-        if ! echo "$FULL_TAG" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-          echo "Error: Invalid tag '$FULL_TAG'"
-          exit 1
-        fi
+      - name: Download package artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package-update
+          path: ${{ env.PKG_DIR }}
 
-        if ! echo "$WINDOWS_SHA" | grep -qE '^[0-9a-f]{64}$'; then
-          echo "Error: Invalid SHA256 for WINDOWS_SHA"
-          exit 1
-        fi
+      - name: Setup Git Identity
+        uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
-    # ── Map component ➜ metadata --------------------------------------------
-    - id: meta
-      name: Resolve paths / flags
-      shell: bash
-      run: |
-        case "$COMPONENT" in
-          gardenlogin)
-            echo "SCRIPT=.github/workflows/update-gardenlogin.ps1" >> $GITHUB_OUTPUT
-            echo "NUSPEC=gardenlogin/gardenlogin.nuspec"           >> $GITHUB_OUTPUT
-            echo "PKG_DIR=gardenlogin"                             >> $GITHUB_OUTPUT
-            echo "PKG_NAME=gardenlogin"                            >> $GITHUB_OUTPUT
-            echo "SKIP_VAR=SKIP_CHOCO_PUSH_GARDENLOGIN"            >> $GITHUB_OUTPUT
-            echo "EXTRA_PATHS=gardenlogin/tools/chocolateyinstall.ps1 gardenlogin/tools/chocolateyuninstall.ps1" >> $GITHUB_OUTPUT
-            ;;
-          gardenctl-v2)
-            echo "SCRIPT=.github/workflows/update-gardenctl-v2.ps1" >> $GITHUB_OUTPUT
-            echo "NUSPEC=gardenctl-v2/gardenctl-v2.nuspec"          >> $GITHUB_OUTPUT
-            echo "PKG_DIR=gardenctl-v2"                             >> $GITHUB_OUTPUT
-            echo "PKG_NAME=gardenctl-v2"                            >> $GITHUB_OUTPUT
-            echo "SKIP_VAR=SKIP_CHOCO_PUSH_GARDENCTL_V2"            >> $GITHUB_OUTPUT
-            echo "EXTRA_PATHS=gardenctl-v2/tools/chocolateyinstall.ps1" >> $GITHUB_OUTPUT
-            ;;
-          diki)
-            echo "SCRIPT=.github/workflows/update-diki.ps1"         >> $GITHUB_OUTPUT
-            echo "NUSPEC=diki/diki.nuspec"                          >> $GITHUB_OUTPUT
-            echo "PKG_DIR=diki"                                     >> $GITHUB_OUTPUT
-            echo "PKG_NAME=diki"                                    >> $GITHUB_OUTPUT
-            echo "SKIP_VAR=SKIP_CHOCO_PUSH_DIKI"                    >> $GITHUB_OUTPUT
-            echo "EXTRA_PATHS=diki/tools/chocolateyinstall.ps1"     >> $GITHUB_OUTPUT
-            ;;
-          *) echo "Invalid component: $COMPONENT" && exit 1 ;;
-        esac
+      - name: Get GitHub Token
+        uses: gardener/cc-utils/.github/actions/github-auth@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+        id: token
+        with:
+          token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}
+          repositories: ${{ github.event.repository.name }}
+          permissions: |
+            pull-requests: write
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      with:
-        persist-credentials: false
+      - name: Create / update pull request
+        shell: bash
+        env:
+          GIT_PUSH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          BASIC_AUTH="$(printf 'x-access-token:%s' "$GIT_PUSH_TOKEN" | base64 | tr -d '\n')"
+          AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
 
-    # ── Update nuspec & helper scripts ---------------------------------------
-    - name: Update package source files
-      shell: pwsh
-      env:
-        SCRIPT: ${{ steps.meta.outputs.SCRIPT }}
-      run: |
-        & "$env:SCRIPT" `
-          "$env:FULL_TAG" `
-          "$env:WINDOWS_SHA"
+          echo "::add-mask::$GIT_PUSH_TOKEN"
+          echo "::add-mask::$BASIC_AUTH"
+          echo "::add-mask::$AUTH_HEADER"
 
-    # ── Pack -----------------------------------------------------------------
-    - name: Choco pack
-      shell: pwsh
-      env:
-        NUSPEC: ${{ steps.meta.outputs.NUSPEC }}
-        PKG_DIR: ${{ steps.meta.outputs.PKG_DIR }}
-      run: |
-        choco pack $env:NUSPEC `
-                   --version $env:NUM_VERSION `
-                   -y --outdir $env:PKG_DIR
+          git_with_auth() {
+            GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+            GIT_CONFIG_VALUE_0="$AUTH_HEADER" \
+            git "$@"
+          }
 
-    # ── Push (repo flag & manual flag respected) -----------------------------
-    - name: Choco push
-      if: ${{ vars[steps.meta.outputs.SKIP_VAR] != 'true' &&
-              (github.event_name == 'repository_dispatch' ||
-               inputs.push_to_chocolatey) }}
-      shell: pwsh
-      env:
-        CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-        PKG_DIR: ${{ steps.meta.outputs.PKG_DIR }}
-        PKG_NAME: ${{ steps.meta.outputs.PKG_NAME }}
-      run: |
-        choco push "$env:PKG_DIR\$env:PKG_NAME.$env:NUM_VERSION.nupkg" `
-                   --source https://chocolatey.org `
-                   -k $env:CHOCOLATEY_API_KEY
+          branch="update_${COMPONENT}_${FULL_TAG}"
+          git switch -c "$branch"
 
-    - name: Push skipped
-      if: ${{ vars[steps.meta.outputs.SKIP_VAR] == 'true' ||
-              (github.event_name == 'workflow_dispatch' && !inputs.push_to_chocolatey) }}
-      run: echo "Chocolatey push skipped."
+          git add "${PKG_DIR}/${PKG_NAME}.${NUM_VERSION}.nupkg"
+          git add "$NUSPEC"
+          for p in $EXTRA_PATHS; do
+            git add "$p"
+          done
 
-    # ── Git identity ---------------------------------------------------------
-    - name: Setup Git Identity
-      uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+          git commit -m "update $COMPONENT to $FULL_TAG" || echo "nothing new"
+          git_with_auth push --force-with-lease -u origin "$branch"
 
-    # ── Pull request ---------------------------------------------------------
-    - name: Install yq
-      run: |
-        choco install yq
-
-    - name: Get GitHub Token
-      uses: gardener/cc-utils/.github/actions/github-auth@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
-      id: token
-      with:
-        token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}
-        repositories: ${{ github.event.repository.name }}
-        permissions: |
-          pull-requests: write
-
-    - name: Create / update pull request
-      shell: bash
-      env:
-        GIT_PUSH_TOKEN: ${{ github.token }}
-        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-        PKG_DIR: ${{ steps.meta.outputs.PKG_DIR }}
-        PKG_NAME: ${{ steps.meta.outputs.PKG_NAME }}
-        NUSPEC: ${{ steps.meta.outputs.NUSPEC }}
-        EXTRA_PATHS: ${{ steps.meta.outputs.EXTRA_PATHS }}
-        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      run: |
-        BASIC_AUTH="$(printf 'x-access-token:%s' "$GIT_PUSH_TOKEN" | base64 | tr -d '\n')"
-        AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
-
-        echo "::add-mask::$GIT_PUSH_TOKEN"
-        echo "::add-mask::$BASIC_AUTH"
-        echo "::add-mask::$AUTH_HEADER"
-
-        git_with_auth() {
-          GIT_CONFIG_COUNT=1 \
-          GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
-          GIT_CONFIG_VALUE_0="$AUTH_HEADER" \
-          git "$@"
-        }
-
-        branch="update_${COMPONENT}_${FULL_TAG}"
-        git switch -c "$branch"
-
-        git add "${PKG_DIR}\\${PKG_NAME}.${NUM_VERSION}.nupkg"
-        git add "$NUSPEC"
-        for p in $EXTRA_PATHS;
-          do git add "$p";
-        done
-
-        git commit -m "update $COMPONENT to $FULL_TAG" || echo "nothing new"
-        git_with_auth push --force-with-lease -u origin "$branch"
-
-        gh pr create \
-          --head "$branch" \
-          --base "$DEFAULT_BRANCH" \
-          --title "update $COMPONENT to $FULL_TAG" \
-          --body  "Updates Chocolatey package for **$COMPONENT** ($FULL_TAG)."
+          gh pr create \
+            --head "$branch" \
+            --base "$DEFAULT_BRANCH" \
+            --title "update $COMPONENT to $FULL_TAG" \
+            --body  "Updates Chocolatey package for **$COMPONENT** ($FULL_TAG)."

--- a/.github/workflows/remote-dispatch.yaml
+++ b/.github/workflows/remote-dispatch.yaml
@@ -143,7 +143,7 @@ jobs:
 
     # ── Git identity ---------------------------------------------------------
     - name: Setup Git Identity
-      uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
+      uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
     # ── Pull request ---------------------------------------------------------
     - name: Install yq
@@ -151,7 +151,7 @@ jobs:
         choco install yq
 
     - name: Get GitHub Token
-      uses: gardener/cc-utils/.github/actions/github-auth@v1
+      uses: gardener/cc-utils/.github/actions/github-auth@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       id: token
       with:
         token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/update-package.yaml
+++ b/.github/workflows/update-package.yaml
@@ -4,7 +4,27 @@ permissions: {}
 
 # ───────────── TRIGGERS ─────────────
 on:
-  repository_dispatch:
+  workflow_call:
+    inputs:
+      component:
+        description: 'Component'
+        required: true
+        type: string
+      tag:
+        description: "Version / tag (e.g. v1.4.0)"
+        required: true
+        type: string
+      windows_sha:
+        description: "Provide sha256 for Windows binary"
+        required: true
+        type: string
+      push_to_chocolatey:
+        description: "true → push .nupkg"
+        type: boolean
+        default: true
+    secrets:
+      CHOCOLATEY_API_KEY:
+        required: false
 
   workflow_dispatch:
     inputs:
@@ -53,9 +73,9 @@ jobs:
         id: validate
         shell: bash
         env:
-          FULL_TAG: ${{ inputs.tag || github.event.client_payload.tag }}
-          COMPONENT: ${{ inputs.component || github.event.client_payload.component }}
-          WINDOWS_SHA: ${{ inputs.windows_sha || github.event.client_payload.windows_sha }}
+          FULL_TAG: ${{ inputs.tag }}
+          COMPONENT: ${{ inputs.component }}
+          WINDOWS_SHA: ${{ inputs.windows_sha }}
         run: |
           case "$COMPONENT" in
             gardenlogin|gardenctl-v2|diki) ;;
@@ -170,8 +190,7 @@ jobs:
     runs-on: windows-latest
     permissions: {}
     if: ${{ vars[needs.resolve-inputs.outputs.skip_var] != 'true' &&
-            (github.event_name == 'repository_dispatch' ||
-             inputs.push_to_chocolatey) }}
+            inputs.push_to_chocolatey == true }}
 
     env:
       NUM_VERSION: ${{ needs.resolve-inputs.outputs.numeric }}
@@ -197,7 +216,9 @@ jobs:
 # 4) CREATE PR — commit generated files, push branch, open PR
 ##############################################################################
   create-pr:
-    needs: [resolve-inputs, package]
+    needs: [resolve-inputs, package, publish-chocolatey]
+    # Run if publish succeeded or was skipped (dry run), but not if it failed
+    if: ${{ !failure() && !cancelled() }}
     runs-on: windows-latest
     permissions:
       contents: write

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,32 @@
+name: Zizmor Workflow Lint
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '.github/**'
+  pull_request:
+    paths:
+    - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.24.1
+          min-severity: low
+          min-confidence: low
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Summary
- Migrate from repository_dispatch to workflow_call pattern
- Split into least-privilege jobs (validate, update-package, create-pr)
- Add input validation for tag and SHA

Test PR for workflow_call migration.